### PR TITLE
README: Fix precedence in incrementIfOdd example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ function incrementIfOdd() {
   return (dispatch, getState) => {
     const { counter } = getState();
 
-    if (counter % 2 === 0) {
+    if ((counter % 2) === 0) {
       return;
     }
 


### PR DESCRIPTION
I noticed this bug when running [redux-chrome-extension](https://github.com/Dharmoslap/redux-chrome-extension/blob/master/src/scripts/shared/actions/chromeExtension.js) and wondering why the "increment if odd" button *always* incremented. :) 

/cc @Dharmoslap