### PR TITLE
Let async actions return something

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,13 @@
 export default function thunkMiddleware({ dispatch, getState }) {
-  return next => action =>
-    typeof action === 'function' ?
-      action(dispatch, getState) :
-      next(action);
+  return next => action => {
+    if (typeof action === 'function') {
+      var returnValue = action(dispatch, getState);
+      if (returnValue !== undefined) {
+        return next(returnValue);
+      }
+    }
+    else {
+      return next(action);
+    }
+  }
 }


### PR DESCRIPTION
Correct me if I'm wrong (and I might be) but I think it would be nice to let async actions return a temporary result down the middleware chain (for example make a spinner visible) until they resolve. Or they can just return nothing if they don't want to.