### PR TITLE
fix: add babel-plugin-add-module-exports for default export

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-   "presets": ["es2015", "stage-0"]
+   "presets": ["es2015", "stage-0"],
+   "plugins": [
+      "add-module-exports"
+   ]
 }

--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
   "license": "MIT",
   "devDependencies": {
     "babel": "^6.1.18",
+    "babel-cli": "^6.2.0",
     "babel-core": "^6.2.1",
     "babel-eslint": "^5.0.0-beta4",
-    "babel-cli": "^6.2.0",
+    "babel-plugin-add-module-exports": "^0.1.1",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-stage-0": "^6.1.18",
     "chai": "^3.2.0",


### PR DESCRIPTION
[upgrading to Babel 6](https://github.com/gaearon/redux-thunk/commit/6577fb6b6b0e557b817012101229c4c1b39ef01a) silently broke everyone using `redux-thunk` with CommonJS `require` and `module.exports` due to [Kill CommonJS default export behaviour - babel/babel#2212](https://phabricator.babeljs.io/T2212). this fixes that (unintended?) breaking change.

see also:

- https://github.com/fcomb/redux-logger/commit/0b34fb9839dec9b565b48a8898a8f2e5faf3a80a
- https://github.com/59naga/babel-plugin-add-module-exports