### PR TITLE
Add .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.babelrc


### PR DESCRIPTION
As discussed [here](https://github.com/rackt/redux/issues/1033#issue-116870190), [and more here](https://github.com/facebook/react-native/issues/4062), excluding `.babelrc` when distributing to npm is the current solution to #43.