### PR TITLE
Enabling thunk to be a property of action instead of function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,13 @@
 function thunkMiddleware({ dispatch, getState }) {
-  return next => action =>
-    typeof action === 'function' ?
-      action(dispatch, getState) :
-      next(action);
+  return next => action => {
+    if (typeof action === 'function') {
+      return action(dispatch, getState);
+    } else if (action && action.thunk && typeof action.thunk === 'function') {
+      return action.thunk(dispatch, getState);
+    } else {
+      return next(action);
+    }
+  }
 }
 
 module.exports = thunkMiddleware

--- a/test/index.js
+++ b/test/index.js
@@ -64,6 +64,26 @@ describe('thunk middleware', () => {
         actionHandler(() => mutated++);
         chai.assert.strictEqual(mutated, 1);
       });
+
+      it('must return value as expected if thunk specified', () => {
+        const expected = 'rocks';
+        const actionHandler = nextHandler();
+
+        let outcome = actionHandler({
+            thunk: () => expected
+        });
+        chai.assert.strictEqual(outcome, expected);
+      });
+
+      it('must be invoked synchronously if thunk specified', () => {
+        const actionHandler = nextHandler();
+        let mutated = 0;
+
+        actionHandler({
+            thunk: () => mutated++
+        });
+        chai.assert.strictEqual(mutated, 1);
+      });
     });
   });
 


### PR DESCRIPTION
Main driver of this change is to ensure that thunk middleware plays nicely with other middlewares. 

To illustrate, please consider this example:

Suppose we need to add middleware to log structured data from actions. Because all actions are objects, you can just send this to server and that is it. You will have nice logs. The only exception to this ideal picture is thunks, which is actually functions,

Another example:

Suppose we need middleware that will detect some field and do something (in my case it asks confirmation). Having actions as an object, gives an ability for multiple middlewares process single action(in my case, first check for confirmation and second is to actually execute thunk). And the only exception are thunks.

_So proposed solution_ is to consider thunk property instead of function:

    function resetPassword (userName) {
            return {
                type: RESET_PASSWORD,
                confirmation: 'Are reallys sure to reset password?',
                thunk: dispatch => {
                    client.resetPassword(userName)
                          .then(() => dispatch(passwordReseted(userName)));
                }
            };
        }