### PR TITLE
fixed eslint errs and added npm lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
   ],
   "scripts": {
     "build": "babel src --out-dir lib",
-    "prepublish": "rimraf lib && npm run build",
-    "test": "mocha --compilers js:babel-core/register --reporter spec test/*.js"
+    "prepublish": "npm run test && rimraf lib && npm run build",
+    "test": "mocha --compilers js:babel-core/register --reporter spec test/*.js",
+    "posttest": "npm run lint",
+    "lint": "eslint src test"
   },
   "repository": {
     "type": "git",
@@ -37,6 +39,7 @@
     "chai": "^3.2.0",
     "eslint": "^1.10.2",
     "eslint-config-airbnb": "1.0.2",
+    "eslint-plugin-react": "^4.1.0",
     "mocha": "^2.2.5",
     "rimraf": "^2.4.3"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -5,4 +5,4 @@ function thunkMiddleware({ dispatch, getState }) {
       next(action);
 }
 
-module.exports = thunkMiddleware
+module.exports = thunkMiddleware;

--- a/test/index.js
+++ b/test/index.js
@@ -45,7 +45,7 @@ describe('thunk middleware', () => {
         const expected = 'redux';
         const actionHandler = nextHandler(() => expected);
 
-        let outcome = actionHandler();
+        const outcome = actionHandler();
         chai.assert.strictEqual(outcome, expected);
       });
 
@@ -53,7 +53,7 @@ describe('thunk middleware', () => {
         const expected = 'rocks';
         const actionHandler = nextHandler();
 
-        let outcome = actionHandler(() => expected);
+        const outcome = actionHandler(() => expected);
         chai.assert.strictEqual(outcome, expected);
       });
 
@@ -71,7 +71,7 @@ describe('thunk middleware', () => {
     it('must throw if argument is non-object', done => {
       try {
         thunkMiddleware();
-      } catch(err) {
+      } catch (err) {
         done();
       }
     });


### PR DESCRIPTION
I noticed that there was an error when running eslint where it couldn't find the 'eslint-plugin-react' module.  Not sure if it's due to the eslint version or perhaps the eslint-config-airbnb dependency. After adding the 'eslint-plugin-react' module the test ran successfully and found some linting errors that are now resolved.