### PR TITLE
feat(umd): Adding umd support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 *.log
 lib
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 *.log
 lib
 dist
+es

--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
     "prepublish": "npm run test && rimraf lib && npm run build",
     "test": "mocha --compilers js:babel-core/register --reporter spec test/*.js",
     "posttest": "npm run lint",
-    "lint": "eslint src test"
+    "lint": "eslint src test",
+    "build": "npm run build:commonjs && npm run build:umd && npm run build:umd:min",
+    "build:commonjs": "babel src --out-dir lib",
+    "build:umd": "NODE_ENV=development webpack",
+    "build:umd:min": "NODE_ENV=production webpack"
   },
   "repository": {
     "type": "git",
@@ -33,6 +37,7 @@
     "babel-cli": "^6.2.0",
     "babel-core": "^6.2.1",
     "babel-eslint": "^5.0.0-beta4",
+    "babel-loader": "^6.2.4",
     "babel-plugin-add-module-exports": "^0.1.1",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-stage-0": "^6.1.18",
@@ -41,6 +46,7 @@
     "eslint-config-airbnb": "1.0.2",
     "eslint-plugin-react": "^4.1.0",
     "mocha": "^2.2.5",
-    "rimraf": "^2.4.3"
+    "rimraf": "^2.4.3",
+    "webpack": "^1.12.14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "test": "mocha --compilers js:babel-core/register --reporter spec test/*.js",
     "posttest": "npm run lint",
     "lint": "eslint src test",
-    "build": "npm run build:commonjs && npm run build:umd && npm run build:umd:min",
+    "build": "npm run build:commonjs && npm run build:umd && npm run build:umd:min && npm run build:es",
     "build:commonjs": "babel src --out-dir lib",
+    "build:es": "BABEL_ENV=es babel src --out-dir es",
     "build:umd": "NODE_ENV=development webpack",
     "build:umd:min": "NODE_ENV=production webpack"
   },

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,0 +1,45 @@
+import webpack from 'webpack';
+import path from 'path';
+
+const { NODE_ENV, TARGET } = process.env;
+
+const  plugins = [
+  new webpack.optimize.OccurenceOrderPlugin(),
+  new webpack.DefinePlugin({
+    'process.env.NODE_ENV': JSON.stringify(NODE_ENV)
+  }),
+];
+
+const filename = `redux-thunk${NODE_ENV === 'production' ? '.min' : ''}.js`;
+
+NODE_ENV === 'production'  && plugins.push(
+  new webpack.optimize.UglifyJsPlugin({
+    compressor: {
+      pure_getters: true,
+      unsafe: true,
+      unsafe_comps: true,
+      screw_ie8: true,
+      warnings: false
+    }
+  })
+);
+
+export default {
+  module: {
+    loaders: [
+      { test: /\.js$/, loaders: ['babel-loader'], exclude: /node_modules/ }
+    ]
+  },
+
+  entry: [
+    './src/index',
+  ],
+
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename,
+    libraryTarget: 'umd',
+  },
+
+  plugins,
+};


### PR DESCRIPTION
Since [Redux](https://github.com/reactjs/redux) has support for UMD, `redux-thunk` should support it as well.

So, this PR adds:

* A minimal webpack config
* Npm build scripts for umd (tried to follow same as Redux does)
* Add `dist` dir into `.gitignore`
