### PR TITLE
remove potentially confusing invocation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you’re not sure whether you need it, you probably don’t.
 
 ## Motivation
 
-Redux Thunk [middleware](https://github.com/reactjs/redux/blob/master/docs/advanced/Middleware.md) allows you to write action creators that return a function instead of an action. The thunk can be used to delay the dispatch of an action, or to dispatch only if a certain condition is met. The inner function receives the store methods `dispatch` and `getState()` as parameters.
+Redux Thunk [middleware](https://github.com/reactjs/redux/blob/master/docs/advanced/Middleware.md) allows you to write action creators that return a function instead of an action. The thunk can be used to delay the dispatch of an action, or to dispatch only if a certain condition is met. The inner function receives the store methods `dispatch` and `getState` as parameters.
 
 An action creator that returns a function to perform asynchronous dispatch:
 


### PR DESCRIPTION
The current phrasing can imply that the thunk is called with `dispatch` and the **invocation** of `getState`, since it says `getState()` but not `dispatch()`. This PR removes the invocation parens from `getState`.