### PR TITLE
Add support for FSA

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "thunk",
     "middleware",
     "redux-middleware",
+    "fsa",
     "flux"
   ],
   "author": "Dan Abramov <dan.abramov@me.com>",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "flux"
   ],
   "author": "Dan Abramov <dan.abramov@me.com>",
+  "contributors": [
+    "Bart van Andel <bavanandel@gmail.com>"
+  ],
   "license": "MIT",
   "devDependencies": {
     "babel-cli": "^6.6.5",
@@ -69,5 +72,8 @@
     "mocha": "^2.2.5",
     "rimraf": "^2.5.2",
     "webpack": "^1.12.14"
+  },
+  "dependencies": {
+    "flux-standard-action": "^0.6.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,19 @@
+import { isFSA } from 'flux-standard-action';
+
+function isFunction(val) {
+  return val && typeof val === 'function';
+}
+
 export default function thunkMiddleware({ dispatch, getState }) {
   return next => action => {
-    if (typeof action === 'function') {
-      return action(dispatch, getState);
+    if (!isFSA(action)) {
+      return isFunction(action)
+        ? action(dispatch, getState)
+        : next(action);
     }
 
-    return next(action);
+    return isFunction(action.payload)
+      ? action.payload(dispatch, getState)
+      : next(action);
   };
 }

--- a/test/index.js
+++ b/test/index.js
@@ -30,7 +30,20 @@ describe('thunk middleware', () => {
         });
       });
 
-      it('must pass action to next if not a function', done => {
+      it('must run the given action function within Flux Standard Actions payload', done => {
+        const actionHandler = nextHandler();
+
+        actionHandler({
+          type: 'foo',
+          payload: (dispatch, getState) => {
+            chai.assert.strictEqual(dispatch, doDispatch);
+            chai.assert.strictEqual(getState, doGetState);
+            done();
+          },
+        });
+      });
+
+      it('must pass action to next if not a function nor a flux standard action', done => {
         const actionObj = {};
 
         const actionHandler = nextHandler(action => {


### PR DESCRIPTION
_Note: Up for discussion._

I was surprised to find out that `redux-thunk` did not work with `createActions` from `redux-actions`, whereas `redux-promise` does. So I modified `redux-thunk` to work in a way very similar to what `redux-promise` does: it checks if the action is a FSA, and if so, it checks if its payload is a function and handles accordingly.

Maybe there is a good reason why this wasn't done, like leaving open the possibility to actually return a function in `action.payload`?

Please let me know your thoughts about this.