### PR TITLE
Add withExtraArgument()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,14 @@
-export default function thunkMiddleware({ dispatch, getState }) {
-  return next => action => {
+function createThunkMiddleware(extraArgument) {
+  return ({ dispatch, getState }) => next => action => {
     if (typeof action === 'function') {
-      return action(dispatch, getState);
+      return action(dispatch, getState, extraArgument);
     }
 
     return next(action);
   };
 }
+
+const thunk = createThunkMiddleware();
+thunk.withExtraArgument = createThunkMiddleware;
+
+export default thunk;

--- a/test/index.js
+++ b/test/index.js
@@ -76,4 +76,19 @@ describe('thunk middleware', () => {
       }
     });
   });
+
+  describe('withExtraArgument', () => {
+    it('must pass the third argument', done => {
+      const extraArg = { lol: true };
+      thunkMiddleware.withExtraArgument(extraArg)({
+        dispatch: doDispatch,
+        getState: doGetState,
+      })()((dispatch, getState, arg) => {
+        chai.assert.strictEqual(dispatch, doDispatch);
+        chai.assert.strictEqual(getState, doGetState);
+        chai.assert.strictEqual(arg, extraArg);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
People often request the ability to inject a custom argument into thunks. While we don’t plan to do this by default so that we don’t have to change the signature of `redux-thunk`, we are adding `thunk.withExtraArgument(arg)` as a way to inject an arbitrary argument into every thunk action creator. This argument will be available as the third argument in the action creators, right after `getState()`.

Example:

```js
const store = createStore(
  reducer,
  applyMiddleware(thunk.withExtraArgument(api))
)

// later
function fetchUser(id) {
  return (dispatch, getState, api) => {
    // you can use api here
  }
}
```

I chose `withExtraArgument` over something more compact like `inject` to make it clear we’re not mutating `redux-thunk` itself, and that this argument will be passed as an extra argument (rather than, for example, instead of, the two usual arguments).