### PR TITLE
Allow state to be injected into a thunk's extraArgument

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,9 +10,12 @@ declare module "redux" {
   }
 }
 
+type StateInjectors = {
+    [key: string]: (getState: () => any) => any;
+}
 
 declare const thunk: Middleware & {
-  withExtraArgument(extraArgument: any): Middleware;
+  withExtraArgument(extraArgument: any, stateInjectors?: StateInjectors): Middleware;
 };
 
 export default thunk;

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,31 @@
-function createThunkMiddleware(extraArgument) {
+function createThunkMiddleware(extraArgument, stateInjectors) {
   return ({ dispatch, getState }) => next => action => {
     if (typeof action === 'function') {
-      return action(dispatch, getState, extraArgument);
+      return action(
+        dispatch,
+        getState,
+        withStateInjected(extraArgument, stateInjectors, getState)
+      );
     }
 
     return next(action);
   };
+}
+
+function withStateInjected(extraArgument = {}, stateInjectors, getState) {
+  if (stateInjectors === undefined) {
+    return extraArgument;
+  }
+
+  const stateInjected = {};
+
+  for (const key in stateInjectors) {
+    if (stateInjectors.hasOwnProperty(key)) {
+      stateInjected[key] = stateInjectors[key](getState);
+    }
+  }
+
+  return Object.assign({}, extraArgument, stateInjected);
 }
 
 const thunk = createThunkMiddleware();

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -14,7 +14,9 @@ store.dispatch((dispatch, getState) => {
   const foo: string = state.foo;
 });
 
-const middleware: Middleware = thunk.withExtraArgument('bar');
+const middlewareWithExtraArgument: Middleware = thunk.withExtraArgument('bar');
+const middlewareWithStateInjectors: Middleware =
+  thunk.withExtraArgument('bar', { state: (getState: any) => getState() });
 
 store.dispatch((dispatch, getState, extraArg) => {
   console.log(extraArg);


### PR DESCRIPTION
Enhance the convenience of `withExtraArguments()` by allowing extra arguments which are resolved from state to be automatically injected into every thunk.

For example, looking at the current example of `withExtraArguments()` usage, where we provide an api as an extra argument. Let's say calls to that api require creds, which are stored somewhere in our state tree. We might then have something like this:

    const store = createStore(
      reducer,
      applyMiddleware(thunk.withExtraArgument({ api, whatever }))
    )

    // later
    function fetchUser(id) {
      return (dispatch, getState, { api, whatever }) => {
        const creds = getState().auth.api.creds;
        return api.get('/secret/1', creds)
          .then(res => api.get(`/secret/2?secret1=${res}`, creds))
          .then(res => dispatch(gotTheSecondSecret(res)));
      }
    }

In usage like this, grabbing the creds, even if we extract it out into some other function, is boilerplate that must be repeated in every single thunk which uses the api.

With this PR we can put this boilerplate in one place by injecting resolved state (or functions which resolve state, for deferred resolution) into the thunk via extraArguments. Here's what the above example looks like now:

    const injectCredsFromState = getState => getState().auth.api.creds;

    const store = createStore(
      reducer,
      // pass the creds state injector function here, 
      // with the key of the extraArgument it should resolve to, 'creds'
      applyMiddleware(thunk.withExtraArgument({ 
        api, 
        whatever 
      }, {
          creds: injectCredsFromState
      }))
    )

    // later
    function fetchUser(id) {
      // creds is injected into the thunk, no need for any boilerplate to resolve it from state
      // also, it is just a value, so the imperative code is gone from the thunk, too
      return (dispatch, getState, { api, whatever, creds }) => (
        api.get('/secret/1', creds)
          .then(res => api.get(`/secret/2?secret1=${res}`, creds))
          .then(res => dispatch(gotTheSecondSecret(res)));
      )
    }

If it's desired to have the resolution of the creds from state be deferred, so that 'fresh' creds are resolved each time , this can be achieved by returning a function from the state injector, which defers the call to getState().

    // don't inject creds value directly, 
    // instead inject a function which defers the creds' resolution from state
    const getCredsFromState = getState => () => getState().auth.api.creds;

    const store = createStore(
      reducer,
      // pass the creds state injector function here, 
      // with the key of the extraArgument it should resolve to, 'creds'
      applyMiddleware(thunk.withExtraArgument({ 
        api, 
        whatever 
      }, {
          getCreds: getCredsFromState
      }))
    )

    // later
    function fetchUser(id) {
      return (dispatch, getState, { api, whatever, getCreds }) => (
        // get the latest creds at api call time, not thunk creation time
        // for example we may create the thunk, then dispatch it much later
        // and user may log out in the meantime, or something
        api.get('/secret/1', getCreds()) 
          .then(res => {
            // creds are updated here - the old creds are now invalid
            dispatch(updateCredsBasedOnFirstSecret(res)); 
            // but it's ok, because getCreds() resolves the latest creds on each call
            return api.get(`/secret/2?secret1=${res}`, getCreds())) 
          .then(res => dispatch(gotTheSecondSecret(res)));
      )
    }
