### PR TITLE
fixed type of thunkAction, which allows us to make custom redux synchronous actions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,13 @@
 import {Middleware, Dispatch} from "redux";
 
-
-export type ThunkAction<R, S, E> = (dispatch: Dispatch<S>, getState: () => S,
-                                    extraArgument: E) => R;
+/**
+	Should extend Action
+	it allows us to make custom action interfaces
+*/
+export interface ThunkAction<R, S, E> extends Action {
+  (dispatch: Dispatch<S>, getState: () => S,
+   extraArgument: E): R; 
+}
 
 declare module "redux" {
   export interface Dispatch<S> {


### PR DESCRIPTION
redux-thunk modifys the default behavior of redux typings [here](https://github.com/vasilevich/redux-thunk/blob/4f96ec0239453623adde857b7e7ad8c4f2897bf1/index.d.ts#L7-L11):
```
declare module "redux" {
  export interface Dispatch<S> {
    <R, E>(asyncAction: ThunkAction<R, S, E>): R;
  }
}
```
this made it impossible for me to create custom synchronous actions(non thuck) because it collided with this definition of the original dispatch interface.

for example:
```
export interface IDefaultAction extends Action {
  type: string;
}
export interface IMiddleware extends Middleware {
  <S>(api: MiddlewareAPI<IStateObject>): (next: Dispatch<IStateObject>) => Dispatch<IStateObject>;
}
export const dataServiceMiddleware: IMiddleware =
  <S>({dispatch, getState}: MiddlewareAPI<IStateObject>) =>
    (next: Dispatch<IStateObject>) => {
      return (action: IDefaultAction): any => {
        /**
do some middleWare
*/
    };
```
resulted in TS errors, because your index.dt.ts [modified](https://github.com/vasilevich/redux-thunk/blob/4f96ec0239453623adde857b7e7ad8c4f2897bf1/index.d.ts#L7-L11) the original redux middleware behavior.


my solution:
make [ThuckAction ](https://github.com/vasilevich/redux-thunk/commit/edb4b76c0c9f292a5931b18e8bb6fb59a3972bf0) interface extend the default [Action ](https://github.com/reactjs/redux/blob/22a1019e83190e39b6e48b7a6cdc9acd49fef9f5/index.d.ts#L16-L18) interface

and then if I want to make my own custom action I can extend that interface aswell.

please consider this pull request,

Thank you!



