### PR TITLE
Add module field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.2.0",
   "description": "Thunk middleware for Redux.",
   "main": "lib/index.js",
+  "module": "es/index.js",
   "jsnext:main": "es/index.js",
   "typings": "./index.d.ts",
   "files": [


### PR DESCRIPTION
The `module` field is the same as the `jsnext:main` field just that it's the newer standard for webpack and rollup.

https://github.com/rollup/rollup/wiki/pkg.module