### PR TITLE
Replace deprecated lifecycle method in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,10 +262,10 @@ class SandwichShop extends Component {
     );
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.forPerson !== this.props.forPerson) {
+  componentDidUpdate(prevProps) {
+    if (prevProps.forPerson !== this.props.forPerson) {
       this.props.dispatch(
-        makeASandwichWithSecretSauce(nextProps.forPerson)
+        makeASandwichWithSecretSauce(this.props.forPerson)
       );
     }
   }


### PR DESCRIPTION
Since React 16.3 deprecates `componentWillReceiveProps`, it would be nice to replace it with `componentDidUpdate`